### PR TITLE
Add scan tag support, separate SCA/SAST toggles, migrate to JUnit 5, and improve logging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-* @jenkinsci/secone-security-scanner-plugin-developers
-* @jenkinsci/secone-security-plugin-developers
-* @rahuldarekar222 @saurabhthatte007
+* @jenkinsci/secone-security-scanner-plugin-developers @rahuldarekar222 @saurabhthatte007

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ pipeline {
             apiCredentialsId: '<Your Sec1 Api Key ID>',
             runSca: true,
             runSast: true,
-            tag: 'my-scan-tag',
+            scanTag: 'my-scan-tag',
             applyThreshold: true,
             actionOnThresholdBreached: 'unstable',
             threshold: [criticalThreshold: '0', highThreshold: '0', mediumThreshold: '0', lowThreshold: '0']
@@ -136,7 +136,7 @@ Whether SCA (Software Composition Analysis) scan needs to be executed for the co
 
 Whether SAST (Static Application Security Testing) scan needs to be executed for the configured git repository.
 
-#### `tag` (optional, default: *branch name*)
+#### `scanTag` (optional, default: *branch name*)
 
 A tag to identify this scan. If not provided, the branch name is used. If the branch name is also unavailable, defaults to `default`.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ pipeline {
             apiCredentialsId: '<Your Sec1 Api Key ID>',
             runSca: true,
             runSast: true,
+            tag: 'my-scan-tag',
             applyThreshold: true,
             actionOnThresholdBreached: 'unstable',
             threshold: [criticalThreshold: '0', highThreshold: '0', mediumThreshold: '0', lowThreshold: '0']
@@ -134,6 +135,10 @@ Whether SCA (Software Composition Analysis) scan needs to be executed for the co
 #### `runSast` (optional, default: `true`)
 
 Whether SAST (Static Application Security Testing) scan needs to be executed for the configured git repository.
+
+#### `tag` (optional, default: *branch name*)
+
+A tag to identify this scan. If not provided, the branch name is used. If the branch name is also unavailable, defaults to `default`.
 
 #### `applyThreshold` (optional, default: `false`)
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 
 	<groupId>io.jenkins.plugins</groupId>
-	<artifactId>secone-security-scanner</artifactId>
+	<artifactId>secone-sca-sast-security-scanner</artifactId>
 	<version>${changelist}</version>
 	<packaging>hpi</packaging>
 
@@ -41,6 +41,7 @@
 		<jenkins.version>${jenkins.baseline}.1</jenkins.version>
 		<changelist>999999-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/secone-security-scanner-plugin</gitHubRepo>
+		<ban-junit4-imports.skip>false</ban-junit4-imports.skip>
 	</properties>
 
 	<dependencyManagement>
@@ -70,6 +71,11 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/io/jenkins/plugins/secone/security/SecOneScannerPlugin.java
+++ b/src/main/java/io/jenkins/plugins/secone/security/SecOneScannerPlugin.java
@@ -90,6 +90,8 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 
 	private boolean runSast;
 
+	private String tag;
+
 	private boolean printInAnsiColor;
 
 	private ObjectFactory objectFactory;
@@ -153,6 +155,15 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 	@DataBoundSetter
 	public void setRunSast(boolean runSast) {
 		this.runSast = runSast;
+	}
+
+	public String getTag() {
+		return tag;
+	}
+
+	@DataBoundSetter
+	public void setTag(String tag) {
+		this.tag = tag;
 	}
 
 	// Backward compatibility
@@ -336,6 +347,8 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 		} catch (Exception ex) {
 			logger.error("Error - extracting branch name for scm url : {}", scmUrl, ex);
 		}
+		String resolvedTag = StringUtils.isNotBlank(tag) ? tag : (StringUtils.isNotBlank(banchName) ? banchName : "default");
+
 		int scaResult = 0;
 		int sastResult = 0;
 		AbortException scaAbortException = null;
@@ -343,7 +356,7 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 		if (runSca) {
 			try {
 				scaResult = runScaScan(fossInstanceUrl, listener, sec1ApiKey, workingDirectory, scmUrl, appName,
-						banchName, dashboardUrl);
+						banchName, dashboardUrl, resolvedTag);
 			} catch (AbortException ex) {
 				if (runSast) {
 					// Save exception to re-throw after SAST scan completes
@@ -359,7 +372,7 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 		if (runSast) {
 			try {
 				sastResult = runSastScan(fossInstanceUrl, listener, sec1ApiKey, workingDirectory, scmUrl, appName,
-						banchName, dashboardUrl);
+						banchName, dashboardUrl, resolvedTag);
 			} catch (InterruptedException ex) {
 				printLogs(listener.getLogger(), "Error while running sast scan. Failed to wait for result.", "r");
 				sastResult = -1;
@@ -381,7 +394,7 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 
 	private int runSastScan(StringBuilder fossInstanceUrl, TaskListener listener, String sec1ApiKey,
 			String workingDirectory, StringBuilder scmUrl, StringBuilder appName, String branchName,
-			String dashboardUrl) throws AbortException, InterruptedException {
+			String dashboardUrl, String resolvedTag) throws AbortException, InterruptedException {
 		printSastStartMessage(listener);
 		int result = 0;
 
@@ -394,6 +407,7 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 
 		requestJson.put("appName", appName);
 		requestJson.put("source", "jenkins");
+		requestJson.put("tag", resolvedTag);
 
 		JSONArray inputParams = new JSONArray();
 		inputParams.put(requestJson);
@@ -402,6 +416,7 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 
 		listener.getLogger().println("-------------------- Sec1 SAST Scan Config --------------------");
 		listener.getLogger().println("SCM Url                " + scmUrl);
+		listener.getLogger().println("Tag                    " + resolvedTag);
 		listener.getLogger().println("Threshold              " + (applyThreshold ? "Enabled" : "Disabled"));
 		if (threshold != null && applyThreshold) {
 			listener.getLogger().println("Threshold Values       Critical: "
@@ -608,7 +623,7 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 
 	private int runScaScan(StringBuilder fossInstanceUrl, TaskListener listener, String sec1ApiKey,
 			String workingDirectory, StringBuilder scmUrl, StringBuilder appName,
-			String branchName, String dashboardUrl) throws AbortException {
+			String branchName, String dashboardUrl, String resolvedTag) throws AbortException {
 
 		printScaStartMessage(listener);
 
@@ -622,6 +637,7 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 		inputParamsMap.put("location", scmUrl);
 		inputParamsMap.put("appName", appName);
 		inputParamsMap.put("source", "jenkins");
+		inputParamsMap.put("tag", resolvedTag);
 		if (StringUtils.isNotBlank(branchName)) {
 			inputParamsMap.put("branchName", getSanitizedBranchName(branchName));
 		}
@@ -631,6 +647,7 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 
 		listener.getLogger().println("-------------------- Sec1 SCA Scan Config --------------------");
 		listener.getLogger().println("SCM Url                " + scmUrl);
+		listener.getLogger().println("Tag                    " + resolvedTag);
 		listener.getLogger().println("Threshold              " + (applyThreshold ? "Enabled" : "Disabled"));
 		if (threshold != null && applyThreshold) {
 			listener.getLogger().println("Threshold Values       Critical: "

--- a/src/main/java/io/jenkins/plugins/secone/security/SecOneScannerPlugin.java
+++ b/src/main/java/io/jenkins/plugins/secone/security/SecOneScannerPlugin.java
@@ -90,7 +90,7 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 
 	private boolean runSast;
 
-	private String tag;
+	private String scanTag;
 
 	private boolean printInAnsiColor;
 
@@ -157,13 +157,22 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 		this.runSast = runSast;
 	}
 
-	public String getTag() {
-		return tag;
+	public String getScanTag() {
+		return scanTag;
 	}
 
 	@DataBoundSetter
+	public void setScanTag(String scanTag) {
+		this.scanTag = scanTag;
+	}
+
+	// Backward compatibility for tag
+	public String getTag() {
+		return scanTag;
+	}
+
 	public void setTag(String tag) {
-		this.tag = tag;
+		this.scanTag = tag;
 	}
 
 	// Backward compatibility
@@ -171,7 +180,6 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 		return runSast;
 	}
 
-	@DataBoundSetter
 	public void setRunSec1SastSecurity(boolean runSec1SastSecurity) {
 		this.runSast = runSec1SastSecurity;
 	}
@@ -347,7 +355,7 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 		} catch (Exception ex) {
 			logger.error("Error - extracting branch name for scm url : {}", scmUrl, ex);
 		}
-		String resolvedTag = StringUtils.isNotBlank(tag) ? tag : (StringUtils.isNotBlank(banchName) ? banchName : "default");
+		String resolvedTag = StringUtils.isNotBlank(scanTag) ? scanTag : (StringUtils.isNotBlank(banchName) ? banchName : "default");
 
 		int scaResult = 0;
 		int sastResult = 0;

--- a/src/main/java/io/jenkins/plugins/secone/security/SecOneScannerPlugin.java
+++ b/src/main/java/io/jenkins/plugins/secone/security/SecOneScannerPlugin.java
@@ -569,10 +569,11 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 				}
 			} catch (AbortException ex) {
 				printSastEndMessage(listener);
-				throw new AbortException(getErrorMessageInAnsi(
-						"Attention: Build Failed because of vulnerability threshold level breached for sast."));
+				throw ex;
 			} catch (IOException ex) {
-				throw new AbortException(getErrorMessageInAnsi("Attention: Build Failed. Check configuration."));
+				logger.error("SAST scan failed with IOException", ex);
+				printSastEndMessage(listener);
+				throw new AbortException(getErrorMessageInAnsi("Attention: Build Failed. Check configuration. " + ex.getMessage()));
 			} catch (URISyntaxException e) {
 				throw new AbortException(getErrorMessageInAnsi("Attention: Check configured Sec1 API url."));
 			}

--- a/src/main/resources/io/jenkins/plugins/secone/security/SecOneScannerPlugin/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/secone/security/SecOneScannerPlugin/config.jelly
@@ -13,7 +13,7 @@
     <f:entry title="Run SAST Scan" field="runSast">
     	<f:checkbox checked="${instance == null || instance.runSast}"/>
 	</f:entry>
-	<f:entry title="Tag" field="tag">
+	<f:entry title="Scan Tag" field="scanTag">
 		<f:textbox default="" />
 	</f:entry>
 	<f:optionalBlock title="${%thresholdTitle}" field="threshold" checked="${instance.threshold != null}">

--- a/src/main/resources/io/jenkins/plugins/secone/security/SecOneScannerPlugin/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/secone/security/SecOneScannerPlugin/config.jelly
@@ -13,6 +13,9 @@
     <f:entry title="Run SAST Scan" field="runSast">
     	<f:checkbox checked="${instance == null || instance.runSast}"/>
 	</f:entry>
+	<f:entry title="Tag" field="tag">
+		<f:textbox default="" />
+	</f:entry>
 	<f:optionalBlock title="${%thresholdTitle}" field="threshold" checked="${instance.threshold != null}">
         <f:block>
             <table style="padding-left:2%; width:100%;">

--- a/src/test/java/io/jenkins/plugins/secone/security/SecOneScannerPluginTest.java
+++ b/src/test/java/io/jenkins/plugins/secone/security/SecOneScannerPluginTest.java
@@ -1,8 +1,8 @@
 package io.jenkins.plugins.secone.security;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -13,27 +13,25 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileInputStream;
-
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.net.URI;
 
-
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
-
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
-
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 
@@ -50,7 +48,8 @@ import io.jenkins.plugins.secone.security.object.factory.ObjectFactory;
 import io.jenkins.plugins.secone.security.pojo.Threshold;
 import jenkins.model.Jenkins;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class SecOneScannerPluginTest {
 
 	@Mock
@@ -93,8 +92,8 @@ public class SecOneScannerPluginTest {
 	@Mock
 	private ObjectFactory objectFactory;
 
-	private static MockedStatic<Jenkins> mockedJenkins;
-	private static MockedStatic<CredentialsProvider> mockedCredentialsProvider;
+	private MockedStatic<Jenkins> mockedJenkins;
+	private MockedStatic<CredentialsProvider> mockedCredentialsProvider;
 
 	private static String WORKSPACE_DIRECTORY_LOCATION;
 
@@ -106,7 +105,7 @@ public class SecOneScannerPluginTest {
 
 	private static InputStream sampleInitiateScaScanResponseStream;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 
 		WORKSPACE_DIRECTORY_LOCATION = new File("src/test/resources/test-data").getAbsolutePath();
@@ -127,7 +126,7 @@ public class SecOneScannerPluginTest {
 		mockJenkins();
 	}
 
-	@After
+	@AfterEach
 	public void close() {
 		mockedJenkins.close();
 		mockedCredentialsProvider.close();
@@ -154,7 +153,7 @@ public class SecOneScannerPluginTest {
 
 	}
 
-	@Test(expected = AbortException.class)
+	@Test
 	public void testScaScanWithThresholdWhereStatusActionIsFail() throws Exception {
 		plugin.setRunSast(false);
 		plugin.setApplyThreshold(true);
@@ -164,7 +163,7 @@ public class SecOneScannerPluginTest {
 
 		plugin.setThreshold(threshold);
 
-		plugin.perform(abstractBuild, launcher, buildListener);
+		assertThrows(AbortException.class, () -> plugin.perform(abstractBuild, launcher, buildListener));
 
 	}
 
@@ -251,7 +250,7 @@ public class SecOneScannerPluginTest {
 
 	}
 
-	@Test(expected = AbortException.class)
+	@Test
 	public void testScaSastScanWithThresholdWhereStatusActionIsFail() throws Exception {
 		plugin.setRunSast(true);
 		plugin.setApplyThreshold(true);
@@ -261,7 +260,7 @@ public class SecOneScannerPluginTest {
 
 		plugin.setThreshold(threshold);
 
-		plugin.perform(abstractBuild, launcher, buildListener);
+		assertThrows(AbortException.class, () -> plugin.perform(abstractBuild, launcher, buildListener));
 
 	}
 
@@ -323,7 +322,6 @@ public class SecOneScannerPluginTest {
 		CloseableHttpClient client = mock(CloseableHttpClient.class);
 		when(objectFactory.createHttpClient(any(URI.class))).thenReturn(client);
 
-		// when(client.execute(httpPost)).thenReturn(scaHttpResponse);
 		when(client.execute(any(HttpPost.class))).thenReturn(scaHttpResponse).thenReturn(scaStatusHttpResponse)
 				.thenReturn(sastHttpResponse).thenReturn(sastStatusHttpResponse);
 
@@ -344,13 +342,11 @@ public class SecOneScannerPluginTest {
 
 	}
 
-	@Test(expected = AbortException.class)
+	@Test
 	public void testInvalidScmUrl() throws Exception {
 		when(buildListener.getLogger()).thenReturn(System.out);
 		when(abstractBuild.getEnvironment(buildListener)).thenReturn(envVars);
 		when(envVars.get("SEC1_INSTANCE_URL")).thenReturn("https://api.sec1.io");
-
-		// when(envVars.get("WORKSPACE")).thenReturn("idont/exist");
 
 		StringCredentials apiKeyCred = mock(StringCredentials.class);
 
@@ -363,21 +359,22 @@ public class SecOneScannerPluginTest {
 
 		when(apiKeyCred.getSecret().getPlainText()).thenReturn("testApiKey");
 
-		plugin.perform(abstractBuild, launcher, buildListener);
+		assertThrows(AbortException.class, () -> plugin.perform(abstractBuild, launcher, buildListener));
 	}
 
-	@Test(expected = AbortException.class)
+	@Test
 	public void testScanFromUIException() throws Exception {
 		when(buildListener.getLogger()).thenReturn(System.out);
 		when(abstractBuild.getEnvironment(buildListener)).thenReturn(envVars);
 
 		when(envVars.get("WORKSPACE")).thenReturn(WORKSPACE_DIRECTORY_LOCATION);
-		assertEquals(1, plugin.perform(abstractBuild, launcher, buildListener));
+
+		assertThrows(AbortException.class, () -> plugin.perform(abstractBuild, launcher, buildListener));
 	}
 
-	@Test(expected = AbortException.class)
+	@Test
 	public void testPerformFromScriptException() throws Exception {
-		plugin.perform(run, filePath, envVars, launcher, taskListener);
+		assertThrows(AbortException.class, () -> plugin.perform(run, filePath, envVars, launcher, taskListener));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Prepare plugin for next release with improved configurability, better logging, and health score compliance.

### Changes

- **Separate SCA/SAST scan toggles**: Replace single `runSec1SastSecurity` with independent `runSca` and `runSast` parameters
- **Configurable dashboard URL**: Add `SEC1_DASHBOARD_URL` environment variable support, defaults to `https://unified.sec1.io`
- **Scan tag support**: Add `scanTag` parameter to identify scans (defaults to branch name)
- **Improved console logging**: Clean separators, consistent formatting, threshold breach details with `Found: X, Allowed: Y`
- **JUnit 5 migration**: Migrate tests from JUnit 4 to Jupiter (`ban-junit4-imports.skip=false`)
- **Revert artifact ID**: Restore `secone-sca-sast-security-scanner` (cannot rename after release)
- **Independent scan execution**: Failure in one scan does not block the other
- **Better error messages**: Include actual exception details instead of generic messages
- **Pipeline symbol**: Add `sec1Security` symbol (backward compatible with `sec1ScaSastSecurity`)

### Testing done

- All 21 unit tests pass (`mvn clean package`)
- Freestyle project: SCA only, SAST only, and both enabled
- Pipeline project: `sec1Security` symbol with `script {}` block
- Verified `scanTag` sent in both SCA and SAST API requests
- Verified `SEC1_DASHBOARD_URL` override works
- Backward compatibility: `sec1ScaSastSecurity` pipelines still work

### Submitter checklist
- [x] Opening from a topic/feature/bugfix branch
- [x] PR title represents the desired changelog entry
- [x] Changes described above
- [x] Tests provided demonstrating the changes work