### PR TITLE
Add configurable scmUrl parameter for Git URL override

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ pipeline {
         script {
           sec1Security(
             apiCredentialsId: '<Your Sec1 Api Key ID>',
+            scmUrl: 'https://github.com/your-org/your-repo',
             runSca: true,
             runSast: true,
             scanTag: 'my-scan-tag',
@@ -127,6 +128,10 @@ You can pass the following parameters to your `sec1Security` step.
 #### `apiCredentialsId` (required, default: *none*)
 
 Sec1 API Key Credential ID. As configured in "[2. Configure a Sec1 API Token Credential](#2-configure-a-sec1-api-token-credential)".
+
+#### `scmUrl` (optional, default: *auto-detected*)
+
+Git repository URL to scan. If not provided, the plugin attempts to detect it from the workspace `.git/config` or the `GIT_URL` environment variable. Use this parameter when auto-detection fails (e.g., on some pipeline configurations).
 
 #### `runSca` (optional, default: `true`)
 

--- a/src/main/java/io/jenkins/plugins/secone/security/SecOneScannerPlugin.java
+++ b/src/main/java/io/jenkins/plugins/secone/security/SecOneScannerPlugin.java
@@ -92,6 +92,8 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 
 	private String scanTag;
 
+	private String scmUrl;
+
 	private boolean printInAnsiColor;
 
 	private ObjectFactory objectFactory;
@@ -164,6 +166,15 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 	@DataBoundSetter
 	public void setScanTag(String scanTag) {
 		this.scanTag = scanTag;
+	}
+
+	public String getScmUrl() {
+		return scmUrl;
+	}
+
+	@DataBoundSetter
+	public void setScmUrl(String scmUrl) {
+		this.scmUrl = scmUrl;
 	}
 
 	// Backward compatibility for tag
@@ -325,17 +336,22 @@ public class SecOneScannerPlugin extends Builder implements SimpleBuildStep {
 			throw new AbortException(getErrorMessageInAnsi("Exception while getting environment variables."));
 		}
 		String gitUrl = null;
-		try {
-			gitUrl = getGitUrl(workingDirectory);
-			if (StringUtils.isBlank(gitUrl)) {
-				gitUrl = run.getEnvironment(listener).get("GIT_URL");
+		if (StringUtils.isNotBlank(this.scmUrl)) {
+			gitUrl = this.scmUrl;
+			printLogs(listener.getLogger(), "Using configured SCM URL: " + gitUrl, "g");
+		} else {
+			try {
+				gitUrl = getGitUrl(workingDirectory);
+				if (StringUtils.isBlank(gitUrl)) {
+					gitUrl = run.getEnvironment(listener).get("GIT_URL");
+				}
+			} catch (IOException | InterruptedException e) {
+				logger.error("Error - Check your git configuration. ", e);
 			}
-		} catch (IOException | InterruptedException e) {
-			logger.error("Error - Check your git configuration. ", e);
-		}
-		if (StringUtils.isBlank(gitUrl)) {
-			throw new AbortException(
-					getErrorMessageInAnsi("Exception while getting getting git url. Check your git configuration."));
+			if (StringUtils.isBlank(gitUrl)) {
+				throw new AbortException(
+						getErrorMessageInAnsi("Unable to detect Git URL. Please configure 'scmUrl' parameter or check your git configuration."));
+			}
 		}
 		scmUrl.append(gitUrl);
 		StringBuilder appName = new StringBuilder();

--- a/src/main/resources/io/jenkins/plugins/secone/security/SecOneScannerPlugin/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/secone/security/SecOneScannerPlugin/config.jelly
@@ -13,6 +13,9 @@
     <f:entry title="Run SAST Scan" field="runSast">
     	<f:checkbox checked="${instance == null || instance.runSast}"/>
 	</f:entry>
+	<f:entry title="SCM URL" field="scmUrl">
+		<f:textbox default="" />
+	</f:entry>
 	<f:entry title="Scan Tag" field="scanTag">
 		<f:textbox default="" />
 	</f:entry>


### PR DESCRIPTION
- Add scmUrl field with @DataBoundSetter for UI and pipeline configuration
- Use configured scmUrl if provided, fallback to auto-detection from .git/config and GIT_URL env var
- Improve error message to guide users when Git URL detection fails
- Add SCM URL field to config.jelly UI
- Update README with scmUrl parameter documentation and sample script

### Testing done

- All 21 unit tests pass (`mvn clean package`)
- Freestyle project: Verified SCM URL field appears in UI and value is used for scan
- Pipeline project: Verified `scmUrl` parameter works in `sec1Security` step
- Tested auto-detection fallback when `scmUrl` is not provided
- Tested improved error message when Git URL cannot be detected

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
